### PR TITLE
Get total unread from users.labels.get method instead

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -24,15 +24,9 @@ count_was = 0
 
 def update_count(count_was):
     gmail = discovery.build('gmail', 'v1', credentials=file.Storage(CREDENTIALS_PATH).get())
-    label_ids = ['INBOX', 'UNREAD']
+    label = 'INBOX' # Note: default labels are uppercase, such as the inbox or spam label
     user_id = 'me'
-    list = gmail.users().messages().list(userId=user_id, labelIds=label_ids).execute()
-    if 'resultSizeEstimate' in list:
-        count = list['resultSizeEstimate']
-        while 'nextPageToken' in list:
-            page_token = list['nextPageToken']
-            list = gmail.users().messages().list(userId=user_id, labelIds=label_ids, pageToken=page_token).execute()
-            count += list['resultSizeEstimate']
+    count = gmail.users().labels().get(userId=user_id, id=label).execute()['threadsUnread']
     if count > 0:
         print(unread_prefix + str(count), flush=True)
     else:

--- a/launch.py
+++ b/launch.py
@@ -24,8 +24,15 @@ count_was = 0
 
 def update_count(count_was):
     gmail = discovery.build('gmail', 'v1', credentials=file.Storage(CREDENTIALS_PATH).get())
-    list = gmail.users().messages().list(userId='me', q='in:inbox is:unread').execute()
-    count = list['resultSizeEstimate']
+    label_ids = ['INBOX', 'UNREAD']
+    user_id = 'me'
+    list = gmail.users().messages().list(userId=user_id, labelIds=label_ids).execute()
+    if 'resultSizeEstimate' in list:
+        count = list['resultSizeEstimate']
+        while 'nextPageToken' in list:
+            page_token = list['nextPageToken']
+            list = gmail.users().messages().list(userId=user_id, labelIds=label_ids, pageToken=page_token).execute()
+            count += list['resultSizeEstimate']
     if count > 0:
         print(unread_prefix + str(count), flush=True)
     else:


### PR DESCRIPTION
I have a lot of unread messages (shame on me :see_no_evil: :hear_no_evil: :speak_no_evil: :smile:).

The search result in `list` is only the first page. So if you have a lot of unread messages, iterating the result with the `nextPageToken` gives a proper count of the unread messages.