### PR TITLE
fix: 🐛 Remove colour if it is an empty string

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -20,7 +20,11 @@ args = parser.parse_args()
 DIR = Path(__file__).resolve().parent
 CREDENTIALS_PATH = Path(DIR, args.credentials)
 
-unread_prefix = '%{F' + args.color + '}' + args.prefix + ' %{F-}'
+if args.color == "":
+    unread_prefix = args.prefix
+else:
+    unread_prefix = '%{F' + args.color + '}' + args.prefix + ' %{F-}'
+
 error_prefix = '%{F' + args.color + '}\uf06a %{F-}'
 count_was = 0
 


### PR DESCRIPTION
If the given colour string is empty the format should be deleted. So instead of:
```
%{F}icon%{F-}
```
it should display
```
icon
```