### PR TITLE
Avoid crash when session file is empty

### DIFF
--- a/bar_gmail/app.py
+++ b/bar_gmail/app.py
@@ -80,7 +80,7 @@ class Application:
     def run(self):
         session = {'history_id': None, 'unread': None}
         inaccurate = False
-        if self.session_path.is_file():
+        if self.session_path.is_file() and self.session_path.stat().st_size > 0:
             with open(self.session_path, 'r') as f:
                 session = json.loads(f.read())
                 inaccurate = self._is_innacurate(session['time'])


### PR DESCRIPTION
Hello there. Thanks for creating the module. From time to time on my arch linux machine, the session file is empty, causing `bar-gmail` to crash during json parsing:

https://github.com/crabvk/bar-gmail/blob/5253370a505f3a052ff4336e383f7e1a0c5d89d7/bar_gmail/app.py#L83-L84 

I'm not sure what causes the session file to be empty. This PR adds a check for `st_size` to avoid such problem.

